### PR TITLE
Rewrite the script: fix logic and use external config file

### DIFF
--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -18,15 +18,15 @@ email=
 zone_id=
 
 
-attacked=./attacked
+attacked_file=./attacked
 
 # create file "attacked" if doesn't exist
-if [ ! -e $attacked ]; then
-	echo 0 > $attacked
+if [ ! -e $attacked_file ]; then
+	echo 0 > $attacked_file
 fi
 
 
-hasattack=$(cat $attacked)
+hasattack=$(cat $attacked_file)
 
 
 if [ $(echo "$loadavg > $maxload"|bc) -eq 1 ]; then
@@ -34,7 +34,7 @@ if [ $(echo "$loadavg > $maxload"|bc) -eq 1 ]; then
 	if [[ $hasattack = 0 && $1 = 0 ]]; then
 
 		# Active protection
-		echo 1 > $attacked
+		echo 1 > $attacked_file
 		curl -s -X PATCH "https://api.cloudflare.com/client/v4/zones/$zone_id/settings/security_level" \
 						-H "X-Auth-Email: $email" \
 						-H "X-Auth-Key: $api_key" \
@@ -46,7 +46,7 @@ if [ $(echo "$loadavg > $maxload"|bc) -eq 1 ]; then
 		if [[ $hasattack = 1 && $1 = 1 ]]; then
 
 		# Disable Protection
-		echo 0 > $attacked
+		echo 0 > $attacked_file
 		curl -s -X PATCH "https://api.cloudflare.com/client/v4/zones/$zone_id/settings/security_level" \
 						-H "X-Auth-Email: $email" \
 						-H "X-Auth-Key: $api_key" \

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -39,7 +39,7 @@ api_set_mode() {
 		-H "X-Auth-Key: $api_key" \
 		-H "Content-Type: application/json" \
 		--data "{\"value\":\"$mode\"}" \
-	|| echo "Error: failed to set security level to $mode" >&2
+	|| echo "Error: failed to set security level to $mode"
 }
 
 

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -10,13 +10,13 @@ maxload=10
 
 
 # Configuration API Cloudflare
-# You're Global API Key (https://dash.cloudflare.com/profile)
+# Your Global API Key (https://dash.cloudflare.com/profile)
 api_key=
-# Email of your account Cloudflare
+# Email of your Cloudflare account
 email=
 # Zone ID (https://dash.cloudflare.com/_zone-id_/domain.com)
 zone_id=
-
+# Whether to write debug messages to the debug.log file under script dir
 debug=0
 
 

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -16,6 +16,8 @@ api_key=
 email=
 # Zone ID (https://dash.cloudflare.com/_zone-id_/domain.com)
 zone_id=
+# Default security level when there is no attack, see in readme
+default_security_level=high
 # Whether to write debug messages to the debug.log file under script dir
 debug=0
 
@@ -79,7 +81,7 @@ elif [ "$1" -eq 1 ] && [ "$was_under_attack" -eq 1 ] && [ "$under_attack" -eq 0 
 	# Disable Protection
 	[ "$debug" -eq 1 ] && echo "Leaving under-attack mode!"
 	echo 0 > "$attacked_file"
-	api_set_mode high
+	api_set_mode "$default_security_level"
 
 fi
 

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -32,12 +32,12 @@ if [ ! -e $attacked_file ]; then
 fi
 
 
-hasattack=$(cat $attacked_file)
+was_under_attack=$(cat $attacked_file)
 
 
 if [ $(echo "$loadavg > $maxload"|bc) -eq 1 ]; then
 
-	if [[ $hasattack = 0 && $1 = 0 ]]; then
+	if [[ $was_under_attack = 0 && $1 = 0 ]]; then
 
 		# Active protection
 		echo 1 > $attacked_file
@@ -49,7 +49,7 @@ if [ $(echo "$loadavg > $maxload"|bc) -eq 1 ]; then
 	fi
 
 	else
-		if [[ $hasattack = 1 && $1 = 1 ]]; then
+		if [[ $was_under_attack = 1 && $1 = 1 ]]; then
 
 		# Disable Protection
 		echo 0 > $attacked_file

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -49,6 +49,11 @@ fi
 was_under_attack=$(cat $attacked_file)
 under_attack=$(echo "$loadavg > $maxload" | bc)
 
+if [[ "$1" != [01] ]]; then
+	echo "Incorrect usage! Please pass either 0 or 1 as an argument"
+	exit 1
+fi
+
 if [ $1 -eq 0 ] && [ $was_under_attack -eq 0 ] && [ $under_attack -eq 1 ]; then
 	# attack just started and we want to enable under-attack mode
 

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -17,8 +17,14 @@ email=
 # Zone ID (https://dash.cloudflare.com/_zone-id_/domain.com)
 zone_id=
 
-
 attacked_file=./attacked
+
+
+# You can put aforementioned config values either in-place
+# or in the file named 'config' in the script's directory.
+config_file=$(dirname $(basename "$0"))/config
+[ -e "$config_file" ] && source "$config_file"
+
 
 # create file "attacked" if doesn't exist
 if [ ! -e $attacked_file ]; then

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -18,12 +18,12 @@ email=
 zone_id=
 
 
+attacked=./attacked
+
 # create file "attacked" if doesn't exist
 if [ ! -e $attacked ]; then
 	echo 0 > $attacked
 fi
-
-attacked=./attacked
 
 
 hasattack=$(cat $attacked)

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -2,7 +2,7 @@
 
 
 # $1 = 1min, $2 = 5min, $3 = 15min
-loadavg=$(cat /proc/loadavg|awk '{printf "%f", $1}')
+loadavg=$(awk '{printf "%f", $1}' < /proc/loadavg)
 
 
 # load is 10, you can modify this if you want load more than 10
@@ -44,12 +44,12 @@ api_set_mode() {
 
 
 # create file "attacked" if doesn't exist
-if [ ! -e $attacked_file ]; then
-	echo 0 > $attacked_file
+if [ ! -e "$attacked_file" ]; then
+	echo 0 > "$attacked_file"
 fi
 
 
-was_under_attack=$(cat $attacked_file)
+was_under_attack=$(cat "$attacked_file")
 under_attack=$(echo "$loadavg > $maxload" | bc)
 
 if [[ "$1" != [01] ]]; then
@@ -62,21 +62,21 @@ if [ $debug -eq 1 ]; then
 	echo "Load average: $loadavg"
 fi
 
-if [ $1 -eq 0 ] && [ $was_under_attack -eq 0 ] && [ $under_attack -eq 1 ]; then
+if [ "$1" -eq 0 ] && [ "$was_under_attack" -eq 0 ] && [ "$under_attack" -eq 1 ]; then
 	# attack just started and we want to enable under-attack mode
 
 	# Activate protection
-	[ $debug -eq 1 ] && echo "Activating under-attack mode!"
-	echo 1 > $attacked_file
+	[ "$debug" -eq 1 ] && echo "Activating under-attack mode!"
+	echo 1 > "$attacked_file"
 	api_set_mode under_attack
 
-elif [ $1 -eq 1 ] && [ $was_under_attack -eq 1 ] && [ $under_attack -eq 0 ]; then
+elif [ "$1" -eq 1 ] && [ "$was_under_attack" -eq 1 ] && [ "$under_attack" -eq 0 ]; then
 	# attack just finished (and up to 20 minutes passed since) 
 	# and we want to disable under-attack mode
 
 	# Disable Protection
-	[ $debug -eq 1 ] && echo "Leaving under-attack mode!"
-	echo 0 > $attacked_file
+	[ "$debug" -eq 1 ] && echo "Leaving under-attack mode!"
+	echo 0 > "$attacked_file"
 	api_set_mode high
 
 fi

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -17,12 +17,14 @@ email=
 # Zone ID (https://dash.cloudflare.com/_zone-id_/domain.com)
 zone_id=
 
-attacked_file=./attacked
+basedir=$(dirname "$0")
+
+attacked_file=$basedir/attacked
 
 
 # You can put aforementioned config values either in-place
 # or in the file named 'config' in the script's directory.
-config_file=$(dirname $(basename "$0"))/config
+config_file=$basedir/config
 [ -e "$config_file" ] && source "$config_file"
 
 

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -17,6 +17,9 @@ email=
 # Zone ID (https://dash.cloudflare.com/_zone-id_/domain.com)
 zone_id=
 
+debug=0
+
+
 basedir=$(dirname "$0")
 
 attacked_file=$basedir/attacked
@@ -54,10 +57,16 @@ if [[ "$1" != [01] ]]; then
 	exit 1
 fi
 
+if [ $debug -eq 1 ]; then
+	echo "Mode: $1; was under attack: $was_under_attack; now under attack: $under_attack"
+	echo "Load average: $loadavg"
+fi
+
 if [ $1 -eq 0 ] && [ $was_under_attack -eq 0 ] && [ $under_attack -eq 1 ]; then
 	# attack just started and we want to enable under-attack mode
 
 	# Activate protection
+	[ $debug -eq 1 ] && echo "Activating under-attack mode!"
 	echo 1 > $attacked_file
 	api_set_mode under_attack
 
@@ -66,6 +75,7 @@ elif [ $1 -eq 1 ] && [ $was_under_attack -eq 1 ] && [ $under_attack -eq 0 ]; the
 	# and we want to disable under-attack mode
 
 	# Disable Protection
+	[ $debug -eq 1 ] && echo "Leaving under-attack mode!"
 	echo 0 > $attacked_file
 	api_set_mode high
 

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -15,18 +15,18 @@ api_key=
 # Email of your account Cloudflare
 email=
 # Zone ID (https://dash.cloudflare.com/_zone-id_/domain.com)
-zone_id=     
+zone_id=
 
 
-# create file attacking if doesn't exist
-if [ ! -e $attacking ]; then
-	echo 0 > $attacking
+# create file "attacked" if doesn't exist
+if [ ! -e $attacked ]; then
+	echo 0 > $attacked
 fi
 
-attacking=./attacking
+attacked=./attacked
 
 
-hasattack=$(cat $attacking)
+hasattack=$(cat $attacked)
 
 
 if [ $(echo "$loadavg > $maxload"|bc) -eq 1 ]; then
@@ -34,7 +34,7 @@ if [ $(echo "$loadavg > $maxload"|bc) -eq 1 ]; then
 	if [[ $hasattack = 0 && $1 = 0 ]]; then
 
 		# Active protection
-		echo 1 > $attacking
+		echo 1 > $attacked
 		curl -s -X PATCH "https://api.cloudflare.com/client/v4/zones/$zone_id/settings/security_level" \
 						-H "X-Auth-Email: $email" \
 						-H "X-Auth-Key: $api_key" \
@@ -46,7 +46,7 @@ if [ $(echo "$loadavg > $maxload"|bc) -eq 1 ]; then
 		if [[ $hasattack = 1 && $1 = 1 ]]; then
 
 		# Disable Protection
-		echo 0 > $attacking
+		echo 0 > $attacked
 		curl -s -X PATCH "https://api.cloudflare.com/client/v4/zones/$zone_id/settings/security_level" \
 						-H "X-Auth-Email: $email" \
 						-H "X-Auth-Key: $api_key" \

--- a/Cloudflare.sh
+++ b/Cloudflare.sh
@@ -24,6 +24,8 @@ basedir=$(dirname "$0")
 
 attacked_file=$basedir/attacked
 
+[ "$debug" -eq 1 ] && exec > "${logfile:-$basedir/debug.log}"
+
 
 # You can put aforementioned config values either in-place
 # or in the file named 'config' in the script's directory.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Cloudflare-Block
 
-Enable Cloudflare protection " I'm Under Attack! " if the server load is greater than 10. (can be modified)
+This script will enable Cloudflare protection " I'm Under Attack! " if the server's load-average is greater than 10. (can be modified)
 
-**Cloudflare.sh** will create a **attacking** file to check if the protection is enabled or disabled.
+**Cloudflare.sh** will create a file named **attacked** to check if the protection is enabled or disabled.
 
 
 ### Configuration
@@ -16,6 +16,15 @@ cd /root && git clone https://github.com/Machou/Cloudflare-Block.git DDoS
 
 #### Configure you API
 
+Copy config file `config.template` to `config` and edit it:
+add API keys (mandatory) and optionally change some of the other values.
+
+`API_KEY`:	Your Global API Key (https://dash.cloudflare.com/profile)
+`MAIL_ACCOUNT`:	Email of your Cloudflare account
+`DOMAIN`:	Zone ID (https://dash.cloudflare.com/_zone-id_/domain.com)
+```
+
+
 [Cloudflare API Documentation](https://api.cloudflare.com/#zone-settings-get-security-level-setting)
 
 | Mode         | Description   |
@@ -24,12 +33,6 @@ cd /root && git clone https://github.com/Machou/Cloudflare-Block.git DDoS
 | medium       | Threat scores greater than 14 will be challenged  |
 | low          | Threat scores greater than 24 will be challenged  |
 |under_attack  | Under Attack Mode                                 |
-
-```bash
-API_KEY			You're Global API Key (https://dash.cloudflare.com/profile)
-MAIL_ACCOUNT		Email of your Cloudflare account
-DOMAIN			Zone ID (https://dash.cloudflare.com/_zone-id_/domain.com)
-```
 
 
 #### Cron

--- a/config.template
+++ b/config.template
@@ -6,5 +6,7 @@ api_key=
 email=
 # Zone ID (https://dash.cloudflare.com/_zone-id_/domain.com)
 zone_id=
+# Default security level when there is no attack, see in readme
+default_security_level=high
 # Whether to write debug messages to the debug.log file under script dir
 debug=0

--- a/config.template
+++ b/config.template
@@ -1,0 +1,10 @@
+# Copy it to 'config' and change for your liking
+
+# Your Global API Key (https://dash.cloudflare.com/profile)
+api_key=
+# Email of your Cloudflare account
+email=
+# Zone ID (https://dash.cloudflare.com/_zone-id_/domain.com)
+zone_id=
+# Whether to write debug messages to the debug.log file under script dir
+debug=0


### PR DESCRIPTION
Hello.
Your current version of the script keeps API credentials in the script itself.
This is dangerous because some users might accidentally commit their credentials back to the repo, and it becomes hard for them to pull updated versions.
This PR moves configuration to the external file (while still allowing to put them directly in the script).

Also, the script's main logic was broken because it did (alsmost) never disable under-attack mode: see the outer `if` clause which only works when we are under attack (load-average exceeds threshold). I tried to fix it in my version.